### PR TITLE
Allow simple filtering with where using **kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ old_people = people.where(lambda p: p.age > 23) # It's a joke! :) [<Person name=
 old_people.first()                                              # <Person name="Bill" age="41">
 old_people.last()                                               # <Person name="Harry" age="55">
 old_people.any(lambda p: p.name.lower().startswith('b'))        # True
-old_people.where(lambda p: p.age == 55)                         # [<Person name="Harry" age="55">]
+old_people.where(age=55)                         # [<Person name="Harry" age="55">]
 old_people.skip(3).any()                                        # False
 old_people.skip(2).first()                                      # <Person name="Harry" age="55">
 

--- a/linqit/__init__.py
+++ b/linqit/__init__.py
@@ -216,11 +216,16 @@ class List(list):
             return List()
         return self[:count]
 
-    def where(self, expression):
+    def where(self, expression=None, **filters):
         """
         Returns all the objects that fulfill an expression (objects that return True for the expression).
         """
-        selection = filter(expression, self)
+        def filter_function(x):
+            return (expression is None or expression(x)) and all([
+                getattr(x, key) == value
+                for key, value in filters.items()
+            ])
+        selection = filter(filter_function, self)
         return List(selection)
 
     def of_type(self, _type):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -136,6 +136,18 @@ class ListTests(TestCase):
     def test_where_method(self):
         self.assertEqual(self.list.where(lambda p: p.name == 'bob')[0], self.list[0])
 
+    def test_where_method_without_expression(self):
+        self.assertEqual(self.list.where(), self.list)
+
+    def test_where_method_with_filter_kwargs(self):
+        self.assertEqual(self.list.where(name='bob')[0], self.list[0])
+
+    def test_where_method_with_expression_and_filter_kwargs(self):
+        self.assertEqual(self.list.where(lambda x: len(x.name) == 4, age=20)[0], self.list[1])
+
+    def test_where_method_with_multiple_filter_kwargs(self):
+        self.assertEqual(self.list.where(name='bob', age=15), [])
+
     def test_first_method(self):
         self.assertEqual(self.list.first(lambda p: p.name == 'bob'), self.list[0])
 


### PR DESCRIPTION
Hi there, thanks for this nice project! 

I am not familiar with the LINQ/.NET background, but I thought it would be useful to allow filtering using key=value kwargs in `.where(..)`, like so;

```
people.where(name='bob', age=20)
```

This is less powerful than passing a function expression, but for the simple case of matching exact values of certain attributes of the data items this is more elegant. And it can be combined with a function expression if desired;

```
people.where(lambda x: x.age > 25, name='bob')
```